### PR TITLE
Use new prop-types module

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "postcss-cssnext": "^2.8.0",
     "postcss-loader": "^0.13.0",
     "precss": "^1.4.0",
+    "prop-types": "^15.5.8",
     "react-addons-test-utils": "^15.3.2",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",

--- a/src/ReactFlot.jsx
+++ b/src/ReactFlot.jsx
@@ -1,5 +1,6 @@
 import $ from 'jquery';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import equal from 'deep-equal';
 
 import addLabels from './add-labels';


### PR DESCRIPTION
Fixes deprecated warning in [React 15.5.0](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html)